### PR TITLE
Remove version.py module and references

### DIFF
--- a/mcrconpy/__init__.py
+++ b/mcrconpy/__init__.py
@@ -24,12 +24,10 @@ from mcrconpy.exceptions import (
     SocketConnectionError,
 )
 from mcrconpy.models import Command, User
-from mcrconpy.version import VERSION
 
 # Legacy alias for backward compatibility
 RconPy = Rcon
 
-__version__ = VERSION
 __all__ = [
     # Core classes
     "Rcon",
@@ -51,7 +49,4 @@ __all__ = [
     "PasswordError",
     # Legacy
     "RconPy",
-    # Version
-    "VERSION",
-    "__version__",
 ]

--- a/mcrconpy/version.py
+++ b/mcrconpy/version.py
@@ -1,7 +1,0 @@
-"""Version information for mcrconpy."""
-
-from __future__ import annotations
-
-VERSION: str = "0.1.1"
-
-__all__ = ["VERSION"]


### PR DESCRIPTION
Removed the mcrconpy/version.py file and all imports/references to VERSION and __version__ from the __init__.py file, as the version module is no longer needed.